### PR TITLE
Android 10+ Password Database Export via Storage Access Framework

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://jitpack.io" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can sign up to [my Telegram channel](https://t.me/ZeevoX_CI) where the lates
 
 #### For adventurers
 
-This project uses [Android Studio 3.5](https://developer.android.com/studio), where, once installed, you can use the **Import from VCS** feature. Android Studio will clone the repository and attempt to build it. The build will fail.
+This project uses [Android Studio 4.0](https://developer.android.com/studio), where, once installed, you can use the **Import from VCS** feature. Android Studio will clone the repository and attempt to build it. The build will fail.
 
 To fix this, we must create a new JKS keystore and key in the root directory of the project. We will use this to sign your build of the app. This is necessary for the Google Drive backup feature to work, which verifies the APK's signature.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,8 +40,8 @@ android {
             storePassword keystoreProperties['storePassword']
         }
     }
-    dataBinding {
-        enabled = true
+    buildFeatures {
+        dataBinding = true
     }
 
     lintOptions {
@@ -92,19 +92,19 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.google.android.material:material:1.1.0-alpha09'
-    implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
-    implementation 'androidx.recyclerview:recyclerview:1.1.0-beta03'
+    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.preference:preference:1.1.0-rc01'
+    implementation 'androidx.preference:preference:1.1.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation 'androidx.core:core-ktx:1.2.0-alpha03'
-    implementation 'com.google.android.gms:play-services-auth:17.0.0'
-    implementation 'com.google.http-client:google-http-client-gson:1.31.0'
-    implementation 'com.google.api-client:google-api-client-android:1.30.2'
-    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.30.1'
+    implementation 'androidx.core:core-ktx:1.3.0'
+    implementation 'com.google.android.gms:play-services-auth:18.0.0'
+    implementation 'com.google.http-client:google-http-client-gson:1.36.0'
+    implementation 'com.google.api-client:google-api-client-android:1.30.10'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.31.0'
     implementation 'com.google.apis:google-api-services-drive:v3-rev173-1.25.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.41'
+    ext.kotlin_version = '1.3.72'
 
     repositories {
         google()
@@ -23,7 +23,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 21 07:31:32 BST 2019
+#Thu Jul 09 22:38:59 BST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
- Option to export password database was hidden on Android 10 and above, this is an issue
- Add the option to export the password on Android 10+
- It works if storage permission already granted
- Not tested if saving to Google Drive via SAF Android Content provider, use the inbuilt GDrive functionality for that